### PR TITLE
Dev/releasecommand

### DIFF
--- a/api/shuttle/src/main.rs
+++ b/api/shuttle/src/main.rs
@@ -35,7 +35,7 @@ async fn main(
 
     // Get the discord token set in `Secrets.toml`
     let discord_token = secret_store
-        .get("DISCORD_TOKEN_TEST")
+        .get("DISCORD_TOKEN")
         .context("'DISCORD_TOKEN' was not found")?;
 
     use commands::{

--- a/api/shuttle/src/main.rs
+++ b/api/shuttle/src/main.rs
@@ -35,11 +35,12 @@ async fn main(
 
     // Get the discord token set in `Secrets.toml`
     let discord_token = secret_store
-        .get("DISCORD_TOKEN")
+        .get("DISCORD_TOKEN_TEST")
         .context("'DISCORD_TOKEN' was not found")?;
 
     use commands::{
-        hello, help, ut_c_guild_init, ut_c_times_delete, ut_c_times_release, ut_c_times_set,
+        hello, help, register, ut_c_guild_init, ut_c_test, ut_c_times_delete, ut_c_times_release,
+        ut_c_times_set,
     };
     let framework = poise::Framework::builder()
         .options(poise::FrameworkOptions {
@@ -50,6 +51,8 @@ async fn main(
                 ut_c_times_set(),
                 ut_c_times_delete(),
                 ut_c_times_release(),
+                register(),
+                ut_c_test(),
             ],
             // ここでprefixを設定する
             prefix_options: poise::PrefixFrameworkOptions {


### PR DESCRIPTION
メッセージ拡散時に，複数行のメッセージに対応しました．


これまでは改行を含めると，違う引数と判断されて，too many argmentとエラーになっていました．