### PR TITLE
update: deploy action

### DIFF
--- a/.github/workflows/shuttle_deploy.yml
+++ b/.github/workflows/shuttle_deploy.yml
@@ -13,3 +13,4 @@ jobs:
       - uses: shuttle-hq/deploy-action@main
         with:
           deploy-key: ${{ secrets.SHUTTLE_API_KEY }}
+          no-test: "true"


### PR DESCRIPTION
DB依存のテストがデプロイ時に通らない問題がある
そのため．テストの責務はCI側で担保することにして，デプロイ時はテスト無しで行うことで，ひとまずの解決を図る